### PR TITLE
Custom tslint rule: non-undefined-react-node-on-render

### DIFF
--- a/Traducir.Web/src/rules/nonUndefinedReactNodeOnRenderRule.js
+++ b/Traducir.Web/src/rules/nonUndefinedReactNodeOnRenderRule.js
@@ -1,0 +1,30 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const Lint = require("tslint");
+const ts = require("typescript");
+class Rule extends Lint.Rules.AbstractRule {
+    apply(sourceFile) {
+        return this.applyWithWalker(new NonUndefinedReactNodeOnRenderWalker(sourceFile, this.getOptions()));
+    }
+}
+Rule.FailureString = `In Component and PureComponent, render() return type should be "NonUndefinedReactNode".`;
+exports.Rule = Rule;
+// tslint:disable-next-line:max-classes-per-file
+class NonUndefinedReactNodeOnRenderWalker extends Lint.RuleWalker {
+    visitMethodDeclaration(node) {
+        if (node.name.getText() === "render" &&
+            node.type &&
+            node.type.getText() !== "NonUndefinedReactNode" &&
+            node.parent &&
+            node.parent.kind === ts.SyntaxKind.ClassDeclaration &&
+            node.parent.heritageClauses &&
+            node.parent.heritageClauses.some(h => h.token === ts.SyntaxKind.ExtendsKeyword &&
+                h.types.some(t => {
+                    const baseClass = t.expression.getText();
+                    return baseClass === "React.Component" || baseClass === "React.PureComponent";
+                }))) {
+            this.addFailureAtNode(node.type, Rule.FailureString, Lint.Replacement.replaceNode(node.type, "NonUndefinedReactNode"));
+        }
+        super.visitMethodDeclaration(node);
+    }
+}

--- a/Traducir.Web/src/rules/nonUndefinedReactNodeOnRenderRule.ts
+++ b/Traducir.Web/src/rules/nonUndefinedReactNodeOnRenderRule.ts
@@ -1,0 +1,39 @@
+import * as Lint from "tslint";
+import * as ts from "typescript";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FailureString: string = `In Component and PureComponent, render() return type should be "NonUndefinedReactNode".`;
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new NonUndefinedReactNodeOnRenderWalker(sourceFile, this.getOptions()));
+    }
+}
+
+// tslint:disable-next-line:max-classes-per-file
+class NonUndefinedReactNodeOnRenderWalker extends Lint.RuleWalker {
+    public visitMethodDeclaration(node: ts.MethodDeclaration): void {
+        if (
+            node.name.getText() === "render" &&
+            node.type &&
+            node.type.getText() !== "NonUndefinedReactNode" &&
+            node.parent &&
+            node.parent.kind === ts.SyntaxKind.ClassDeclaration &&
+            node.parent.heritageClauses &&
+            node.parent.heritageClauses.some(h =>
+                h.token === ts.SyntaxKind.ExtendsKeyword &&
+                h.types.some(t => {
+                    const baseClass = t.expression.getText();
+                    return baseClass === "React.Component" || baseClass === "React.PureComponent";
+                })
+            )
+        ) {
+            this.addFailureAtNode(
+                node.type,
+                Rule.FailureString,
+                Lint.Replacement.replaceNode(node.type, "NonUndefinedReactNode")
+            );
+        }
+
+        super.visitMethodDeclaration(node);
+    }
+}

--- a/Traducir.Web/tslint.json
+++ b/Traducir.Web/tslint.json
@@ -21,7 +21,14 @@
     "jsx-wrap-multiline": false,
     "jsx-boolean-value": false,
     "jsx-no-multiline-js": false,
-    "typedef": [true, "call-signature", "parameter", "property-declaration", "member-variable-declaration"]
+    "typedef": [
+      true,
+      "call-signature",
+      "parameter",
+      "property-declaration",
+      "member-variable-declaration"
+    ],
+    "non-undefined-react-node-on-render": true
   },
-  "rulesDirectory": []
+  "rulesDirectory": "./src/rules"
 }


### PR DESCRIPTION
Added a custom tslint rule with a fix to prevent returning `React.ReactNode` on `render()` method of `Component` and `PureComponent`. The fix changes the return type to `NonUndefinedReactNode`

## Instructions ##
> Note: There is no need to perform any of these steps as the rule is already compiled and picked by webpack and tslint


### Recompile after modifying the rule code ###

    tsc src/rules/nonUndefinedReactNodeOnRenderRule.ts --target "ES6" --module "commonjs"

### Manually running tslint

    tslint --project .

### Autoapplying fixes when running tslint ###
> Note: It will change the source code to apply fixes where possible

    tslint --project . --fix 