### PR TITLE
Added copy button for translation #82

### DIFF
--- a/Traducir.Web/src/App/Components/Suggestions.tsx
+++ b/Traducir.Web/src/App/Components/Suggestions.tsx
@@ -61,6 +61,11 @@ export default class Suggestions extends React.Component<ISuggestionsProps, ISug
                     <pre className="d-inline">{this.props.str.translation}</pre> :
                     <i>Missing translation</i>}
             </div>
+            {this.props.user && this.props.str.translation && < div >
+                <button type="button" className="btn btn-sm btn-primary" onClick={this.copyTranslatedString}>
+                    Copy as suggestion
+                </button>
+            </div>}
             <SuggestionsTable
                 user={this.props.user}
                 config={this.props.config}
@@ -98,6 +103,12 @@ export default class Suggestions extends React.Component<ISuggestionsProps, ISug
     public copyOriginalString(): void {
         this.setState({ suggested: this.props.str.originalString });
     }
+
+    @autobind()
+    public copyTranslatedString(): void {
+        this.setState({ suggested: this.props.str.translation });
+    }
+
 
     @autobind()
     public setUrgent(): void {

--- a/Traducir.Web/src/App/Components/Suggestions.tsx
+++ b/Traducir.Web/src/App/Components/Suggestions.tsx
@@ -109,7 +109,6 @@ export default class Suggestions extends React.Component<ISuggestionsProps, ISug
         this.setState({ suggested: this.props.str.translation });
     }
 
-
     @autobind()
     public setUrgent(): void {
         this.updateUrgency(true);


### PR DESCRIPTION
Added a button on Suggestion pop up. Button only render for logged user and if a translation exists. 

Fixed #82 

Copy current translation to suggestion box.