### PR TITLE
Let devs avoid upserting the user on log in

### DIFF
--- a/Traducir.Api/Controllers/AccountController.cs
+++ b/Traducir.Api/Controllers/AccountController.cs
@@ -69,19 +69,14 @@ namespace Traducir.Api.Controllers
                 return Content($"You need at least {minRep} to log in");
             }
 
-            // For development, only execute this if UPSERT_USER: true
-            if (_configuration.GetValue<string>("ASPNETCORE_ENVIRONMENT") != "Development" ||
-                _configuration.GetValue<bool>("UPSERT_USER"))
+            await _userService.UpsertUserAsync(new User
             {
-                await _userService.UpsertUserAsync(new User
-                {
-                    Id = currentUser.UserId,
-                    DisplayName = currentUser.DisplayName,
-                    IsModerator = currentUser.UserType == "moderator",
-                    CreationDate = DateTime.UtcNow,
-                    LastSeenDate = DateTime.UtcNow
-                });
-            }
+                Id = currentUser.UserId,
+                DisplayName = currentUser.DisplayName,
+                IsModerator = currentUser.UserType == "moderator",
+                CreationDate = DateTime.UtcNow,
+                LastSeenDate = DateTime.UtcNow
+            });
 
             var user = await _userService.GetUserAsync(currentUser.UserId);
 

--- a/Traducir.Api/Controllers/AccountController.cs
+++ b/Traducir.Api/Controllers/AccountController.cs
@@ -69,14 +69,19 @@ namespace Traducir.Api.Controllers
                 return Content($"You need at least {minRep} to log in");
             }
 
-            await _userService.UpsertUserAsync(new User
+            // For development, only execute this if UPSERT_USER: true
+            if (_configuration.GetValue<string>("ASPNETCORE_ENVIRONMENT") != "Development" ||
+                _configuration.GetValue<bool>("UPSERT_USER"))
             {
-                Id = currentUser.UserId,
-                DisplayName = currentUser.DisplayName,
-                IsModerator = currentUser.UserType == "moderator",
-                CreationDate = DateTime.UtcNow,
-                LastSeenDate = DateTime.UtcNow
-            });
+                await _userService.UpsertUserAsync(new User
+                {
+                    Id = currentUser.UserId,
+                    DisplayName = currentUser.DisplayName,
+                    IsModerator = currentUser.UserType == "moderator",
+                    CreationDate = DateTime.UtcNow,
+                    LastSeenDate = DateTime.UtcNow
+                });
+            }
 
             var user = await _userService.GetUserAsync(currentUser.UserId);
 


### PR DESCRIPTION
Prevent executing upsert on develop, I added a key on package.json:
 **"UPSERT_USER": true**

If not found, nothing happends. It's only checked in develop. That way, we can avoid UPSERT the user if we want, and change flags according to the data on database. 

closes #100 