### PR TITLE
Allow edit

### DIFF
--- a/Traducir.Api/Controllers/StringsController.cs
+++ b/Traducir.Api/Controllers/StringsController.cs
@@ -307,6 +307,23 @@ namespace Traducir.Api.Controllers
             return BadRequest();
         }
 
+        [HttpPut]
+        [Authorize(Policy = TraducirPolicy.CanSuggest)]
+        [Route("app/api/suggestions/replace")]
+        public async Task<IActionResult> ReplaceSuggestion([FromBody] ReplaceSuggestionViewModel replaceSuggestionViewModel)
+        {
+            var success = await _soStringService.ReplaceSuggestionAsync(
+                replaceSuggestionViewModel.SuggestionId,
+                replaceSuggestionViewModel.NewSuggestion,
+                User.GetClaim<int>(ClaimType.Id));
+            if (success)
+            {
+                return NoContent();
+            }
+
+            return BadRequest();
+        }
+
         private static string FixWhitespaces(string suggestion, string original)
         {
             var match = WhitespacesRegex.Match(original);

--- a/Traducir.Api/ViewModels/Strings/ReplaceSuggestionViewModel.cs
+++ b/Traducir.Api/ViewModels/Strings/ReplaceSuggestionViewModel.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Traducir.Api.ViewModels.Strings
+{
+    public class ReplaceSuggestionViewModel
+    {
+        public string NewSuggestion { get; set; }
+
+        public int SuggestionId { get; set; }
+    }
+}

--- a/Traducir.Core/Models/Enums/StringSuggestionHistoryType.cs
+++ b/Traducir.Core/Models/Enums/StringSuggestionHistoryType.cs
@@ -8,6 +8,7 @@ namespace Traducir.Core.Models.Enums
         RejectedByTrusted = 4,
         RejectedByReviewer = 5,
         DeletedByOwner = 6,
-        DismissedByOtherString = 7
+        DismissedByOtherString = 7,
+        ReplacedByOwner = 8
     }
 }

--- a/Traducir.Migrations/Migrations/012 - AddStringSuggestionHistoryTypeForReplace.cs
+++ b/Traducir.Migrations/Migrations/012 - AddStringSuggestionHistoryTypeForReplace.cs
@@ -1,0 +1,30 @@
+using SimpleMigrations;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Traducir.Migrations.Migrations
+{
+
+    [Migration(12, "Add new suggestion history type")]
+    class AddSuggestionHistoryTypeForReplace: Migration
+    {
+        protected override void Up()
+        {
+            Execute(@"
+Insert into StringSuggestionHistoryTypes
+Values (8, 'ReplacedByOwner', 'The suggestion was replaced by its owner');
+");
+
+        }
+
+        protected override void Down()
+        {
+            Execute(@"
+Delete
+From StringSuggestionHistoryTypes
+Where id = 8;");
+        }
+
+    }
+}

--- a/Traducir.Web/src/App/Components/Suggestion.tsx
+++ b/Traducir.Web/src/App/Components/Suggestion.tsx
@@ -103,12 +103,13 @@ export default class Suggestion extends React.Component<ISuggestionProps, ISugge
             isButtonDisabled: true
         });
         try {
-            await axios.post("/app/api/suggestions/replace",
+            await axios.put("/app/api/suggestions/replace",
             {
                 NewSuggestion: this.props.stringToReplace,
                 SuggestionId: this.props.sug.id
             });
             this.props.refreshString(this.props.sug.stringId);
+            history.push("/filters");
         } catch (e) {
             if (e.response.status === 400) {
                 this.props.showErrorMessage("Error replacing the suggestion. Do you have enough rights?");

--- a/Traducir.Web/src/App/Components/Suggestion.tsx
+++ b/Traducir.Web/src/App/Components/Suggestion.tsx
@@ -14,6 +14,7 @@ interface ISuggestionProps {
     user?: IUserInfo;
     refreshString: (stringIdToUpdate: number) => void;
     showErrorMessage: (messageOrCode: string | number) => void;
+    stringToReplace: string;
 }
 
 interface ISuggestionState {
@@ -53,8 +54,18 @@ export default class Suggestion extends React.Component<ISuggestionProps, ISugge
                 </a>
             </td>
             <td>{this.renderDeleteButton()}</td>
+            <td>{this.renderReplaceButton()}</td>
             <td>{this.renderSuggestionActions()}</td>
         </tr>;
+    }
+
+    public renderReplaceButton(): React.ReactNode {
+        if (this.props.user && this.props.sug.createdById === this.props.user.id) {
+            return <button type="button" className="btn btn-sm btn-danger" onClick={this.replaceReview} disabled={this.state.isButtonDisabled || this.props.stringToReplace.length === 0}>
+                REPLACE
+        </button>;
+        }
+
     }
 
     public renderDeleteButton(): React.ReactNode {
@@ -84,6 +95,31 @@ export default class Suggestion extends React.Component<ISuggestionProps, ISugge
                 <i className="fas fa-thumbs-down" />
             </button>
         </div>;
+    }
+
+    @autobind()
+    public async replaceReview(): Promise<void> {
+        this.setState({
+            isButtonDisabled: true
+        });
+        try {
+            await axios.post("/app/api/suggestions/replace",
+            {
+                NewSuggestion: this.props.stringToReplace,
+                SuggestionId: this.props.sug.id
+            });
+            this.props.refreshString(this.props.sug.stringId);
+        } catch (e) {
+            if (e.response.status === 400) {
+                this.props.showErrorMessage("Error replacing the suggestion. Do you have enough rights?");
+            } else {
+                this.props.showErrorMessage(e.response.status);
+            }
+        } finally {
+            this.setState({
+                isButtonDisabled: false
+            });
+        }
     }
 
     @autobind()
@@ -141,4 +177,5 @@ export default class Suggestion extends React.Component<ISuggestionProps, ISugge
             });
         }
     }
+
 }

--- a/Traducir.Web/src/App/Components/SuggestionNew.tsx
+++ b/Traducir.Web/src/App/Components/SuggestionNew.tsx
@@ -15,6 +15,7 @@ export interface ISuggestionNewProps {
     refreshString: (stringIdToUpdate: number) => void;
     showErrorMessage: (messageOrCode: string | number) => void;
     suggestion: string;
+    hasNewSuggestion: (newSuggestion: string) => void;
 }
 
 interface ISuggestionNewState {
@@ -91,6 +92,7 @@ export default class SuggestionNew extends React.Component<ISuggestionNewProps, 
     @autobind()
     public updateSuggestion(e: React.ChangeEvent<HTMLTextAreaElement>): void {
         this.setState({ suggestion: e.target.value });
+        this.props.hasNewSuggestion(e.target.value);
     }
 
     @autobind()

--- a/Traducir.Web/src/App/Components/Suggestions.tsx
+++ b/Traducir.Web/src/App/Components/Suggestions.tsx
@@ -72,6 +72,7 @@ export default class Suggestions extends React.Component<ISuggestionsProps, ISug
                 suggestions={this.props.str.suggestions}
                 refreshString={this.props.refreshString}
                 showErrorMessage={this.props.showErrorMessage}
+                stringToReplace={this.state.suggested}
             />
 
             <SuggestionNew
@@ -81,8 +82,14 @@ export default class Suggestions extends React.Component<ISuggestionsProps, ISug
                 refreshString={this.props.refreshString}
                 showErrorMessage={this.props.showErrorMessage}
                 suggestion={this.state.suggested}
+                hasNewSuggestion={this.hasNewSuggestion}
             />
         </>;
+    }
+
+    @autobind
+    public hasNewSuggestion(NewSuggestion: string): void {
+        this.setState({suggested: NewSuggestion});
     }
 
     public renderUrgency(): React.ReactNode {

--- a/Traducir.Web/src/App/Components/SuggestionsTable.tsx
+++ b/Traducir.Web/src/App/Components/SuggestionsTable.tsx
@@ -13,6 +13,7 @@ export interface ISuggestionsTableProps {
     user?: IUserInfo;
     refreshString: (stringIdToUpdate: number) => void;
     showErrorMessage: (messageOrCode: string | number) => void;
+    stringToReplace: string;
 }
 
 export default class SuggestionsTable extends React.Component<ISuggestionsTableProps> {
@@ -39,6 +40,7 @@ export default class SuggestionsTable extends React.Component<ISuggestionsTableP
                     user={this.props.user}
                     refreshString={this.props.refreshString}
                     showErrorMessage={this.props.showErrorMessage}
+                    stringToReplace={this.props.stringToReplace}
                 />)}
             </tbody>
         </table>;

--- a/Traducir.Web/src/Models/SOStringSuggestionHistory.ts
+++ b/Traducir.Web/src/Models/SOStringSuggestionHistory.ts
@@ -15,7 +15,7 @@ export enum SuggestionHistoryType {
     RejectedByReviewer = 5,
     DeletedByOwner = 6,
     DismissedByOtherString = 7,
-    ReplacedByUser = 8
+    ReplacedByOwner = 8
 }
 
 export function suggestionHistoryTypeToString(historyType: SuggestionHistoryType): string {
@@ -34,7 +34,7 @@ export function suggestionHistoryTypeToString(historyType: SuggestionHistoryType
             return "Deleted by owner";
         case SuggestionHistoryType.DismissedByOtherString:
             return "Dismissed by other string";
-        case SuggestionHistoryType.ReplacedByUser:
+        case SuggestionHistoryType.ReplacedByOwner:
             return "Replaced by owner";
     }
     return "Unknown";

--- a/Traducir.Web/src/Models/SOStringSuggestionHistory.ts
+++ b/Traducir.Web/src/Models/SOStringSuggestionHistory.ts
@@ -14,7 +14,8 @@ export enum SuggestionHistoryType {
     RejectedByTrusted = 4,
     RejectedByReviewer = 5,
     DeletedByOwner = 6,
-    DismissedByOtherString = 7
+    DismissedByOtherString = 7,
+    ReplacedByUser = 8
 }
 
 export function suggestionHistoryTypeToString(historyType: SuggestionHistoryType): string {
@@ -33,6 +34,8 @@ export function suggestionHistoryTypeToString(historyType: SuggestionHistoryType
             return "Deleted by owner";
         case SuggestionHistoryType.DismissedByOtherString:
             return "Dismissed by other string";
+        case SuggestionHistoryType.ReplacedByUser:
+            return "Replaced by owner";
     }
     return "Unknown";
 }


### PR DESCRIPTION

the idea is.:
Have a replace button on the suggestion table. Only show this button to the owner.
Replace suggestion on DB.
Add this to history.

Front: Add some props to let the suggestionhistory know that there is a new suggestion
Pass that data from the child (new suggestion) to his parent (suggestion) down to the table (and to each row).
Call the back from the row on the grid.

Back: a function similar to the one adding a suggestion, but doing an update and storing that update on history. 
There is a new model to receive the data.
There is a database migration (to add a new historytype)