### PR TITLE
Integrate the Traducir.Web project in the Visual Studio solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 bin/
 obj/
 .vs/
-*.csproj.user
+*.*proj.user
 Traducir.Web/node_modules/
 Traducir.Web/dist/
 /Traducir.Api/Properties/launchSettings.json

--- a/Traducir.Web/Traducir.Web.njsproj
+++ b/Traducir.Web/Traducir.Web.njsproj
@@ -1,0 +1,134 @@
+﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <Name>Traducir.Web</Name>
+    <RootNamespace>Traducir.Web</RootNamespace>
+    <SaveNodeJsSettingsInProjectFile>True</SaveNodeJsSettingsInProjectFile>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>bf303b5e-3289-45fd-a285-5081b4ccbdb2</ProjectGuid>
+    <ProjectHome>.</ProjectHome>
+    <StartupFile>
+    </StartupFile>
+    <SearchPath>
+    </SearchPath>
+    <WorkingDirectory>.</WorkingDirectory>
+    <OutputPath>.</OutputPath>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{349c5851-65df-11da-9384-00065b846f21};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
+    <NodejsPort>1337</NodejsPort>
+    <StartWebBrowser>True</StartWebBrowser>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+  <ItemGroup>
+    <Content Include="lib\bootstrap.min.css" />
+    <Content Include="lib\miniprofiler-includes.4.0.138.gcc91adf599.css" />
+    <Content Include="lib\unicorn.png" />
+    <Content Include="package-lock.json" />
+    <Content Include="package.json" />
+    <Content Include="src\index.ejs" />
+    <Content Include="tsconfig.json" />
+    <Content Include="tslint.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="lib\fontawesome.js" />
+    <Compile Include="lib\miniprofiler.js" />
+    <Compile Include="lib\service-worker.js" />
+    <Compile Include="src\rules\nonUndefinedReactNodeOnRenderRule.js" />
+    <Compile Include="webpack.common.js" />
+    <Compile Include="webpack.dev-hot.js" />
+    <Compile Include="webpack.prod.js" />
+    <Compile Include="webpack.test.js" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="lib\" />
+    <Folder Include="src\" />
+    <Folder Include="src\App\" />
+    <Folder Include="src\App\Components\" />
+    <Folder Include="src\Models\" />
+    <Folder Include="src\rules\" />
+  </ItemGroup>
+  <ItemGroup>
+    <TypeScriptCompile Include="src\App\Components\Filters.tsx" />
+    <TypeScriptCompile Include="src\App\Components\Notifications.tsx" />
+    <TypeScriptCompile Include="src\App\Components\Result.tsx" />
+    <TypeScriptCompile Include="src\App\Components\Results.tsx" />
+    <TypeScriptCompile Include="src\App\Components\StatsWithLinks.tsx" />
+    <TypeScriptCompile Include="src\App\Components\Suggestion.tsx" />
+    <TypeScriptCompile Include="src\App\Components\SuggestionHistoryFilters.tsx" />
+    <TypeScriptCompile Include="src\App\Components\SuggestionNew.tsx" />
+    <TypeScriptCompile Include="src\App\Components\Suggestions.tsx" />
+    <TypeScriptCompile Include="src\App\Components\SuggestionsHistory.tsx" />
+    <TypeScriptCompile Include="src\App\Components\SuggestionsHistoryTable.tsx" />
+    <TypeScriptCompile Include="src\App\Components\SuggestionsTable.tsx" />
+    <TypeScriptCompile Include="src\App\Components\User.tsx" />
+    <TypeScriptCompile Include="src\App\Components\Users.tsx" />
+    <TypeScriptCompile Include="src\App\NonUndefinedReactNode.d.ts" />
+    <TypeScriptCompile Include="src\App\Traducir.tsx" />
+    <TypeScriptCompile Include="src\history.ts" />
+    <TypeScriptCompile Include="src\index-hot.tsx" />
+    <TypeScriptCompile Include="src\index.tsx" />
+    <TypeScriptCompile Include="src\Models\Config.ts" />
+    <TypeScriptCompile Include="src\Models\INotificationSettings.ts" />
+    <TypeScriptCompile Include="src\Models\SOString.ts" />
+    <TypeScriptCompile Include="src\Models\SOStringSuggestion.ts" />
+    <TypeScriptCompile Include="src\Models\SOStringSuggestionHistory.ts" />
+    <TypeScriptCompile Include="src\Models\Stats.ts" />
+    <TypeScriptCompile Include="src\Models\User.ts" />
+    <TypeScriptCompile Include="src\Models\UserInfo.ts" />
+    <TypeScriptCompile Include="src\Models\UserType.ts" />
+    <TypeScriptCompile Include="src\nameofFactory.ts" />
+    <TypeScriptCompile Include="src\rules\nonUndefinedReactNodeOnRenderRule.ts" />
+    <TypeScriptCompile Include="src\urlBase64ToUint8Array.ts" />
+  </ItemGroup>
+  <!-- Do not delete the following Import Project.  While this appears to do nothing it is a marker for setting TypeScript properties before our import that depends on them. -->
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.targets" Condition="False" />
+  <Import Project="$(VSToolsPath)\Node.js Tools\Microsoft.NodejsTools.targets" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>False</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>0</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:48022/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>True</UseCustomServer>
+          <CustomServerUrl>http://localhost:1337</CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}" User="">
+        <WebProjectProperties>
+          <StartPageUrl>
+          </StartPageUrl>
+          <StartAction>CurrentPage</StartAction>
+          <AspNetDebugging>True</AspNetDebugging>
+          <SilverlightDebugging>False</SilverlightDebugging>
+          <NativeDebugging>False</NativeDebugging>
+          <SQLDebugging>False</SQLDebugging>
+          <ExternalProgram>
+          </ExternalProgram>
+          <StartExternalURL>
+          </StartExternalURL>
+          <StartCmdLineArguments>
+          </StartCmdLineArguments>
+          <StartWorkingDirectory>
+          </StartWorkingDirectory>
+          <EnableENC>False</EnableENC>
+          <AlwaysStartWebServerOnDebug>False</AlwaysStartWebServerOnDebug>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+</Project>

--- a/Traducir.sln
+++ b/Traducir.sln
@@ -1,12 +1,16 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28721.148
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Traducir.Api", "Traducir.Api\Traducir.Api.csproj", "{45512CCB-2D89-4060-8245-D9A4D6A4739D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Traducir.Migrations", "Traducir.Migrations\Traducir.Migrations.csproj", "{4C017B12-4268-4976-950F-BF864B40A74E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Traducir.Core", "Traducir.Core\Traducir.Core.csproj", "{3C96AC2E-8595-4861-BA12-79AA3E4E7793}"
+EndProject
+Project("{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}") = "Traducir.Web", "Traducir.Web\Traducir.Web.njsproj", "{BF303B5E-3289-45FD-A285-5081B4CCBDB2}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8B7040D6-BAA7-4677-9B38-D25CE1B46FFD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -54,6 +58,18 @@ Global
 		{3C96AC2E-8595-4861-BA12-79AA3E4E7793}.Release|x64.Build.0 = Release|Any CPU
 		{3C96AC2E-8595-4861-BA12-79AA3E4E7793}.Release|x86.ActiveCfg = Release|Any CPU
 		{3C96AC2E-8595-4861-BA12-79AA3E4E7793}.Release|x86.Build.0 = Release|Any CPU
+		{BF303B5E-3289-45FD-A285-5081B4CCBDB2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF303B5E-3289-45FD-A285-5081B4CCBDB2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF303B5E-3289-45FD-A285-5081B4CCBDB2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BF303B5E-3289-45FD-A285-5081B4CCBDB2}.Debug|x64.Build.0 = Debug|Any CPU
+		{BF303B5E-3289-45FD-A285-5081B4CCBDB2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BF303B5E-3289-45FD-A285-5081B4CCBDB2}.Debug|x86.Build.0 = Debug|Any CPU
+		{BF303B5E-3289-45FD-A285-5081B4CCBDB2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF303B5E-3289-45FD-A285-5081B4CCBDB2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF303B5E-3289-45FD-A285-5081B4CCBDB2}.Release|x64.ActiveCfg = Release|Any CPU
+		{BF303B5E-3289-45FD-A285-5081B4CCBDB2}.Release|x64.Build.0 = Release|Any CPU
+		{BF303B5E-3289-45FD-A285-5081B4CCBDB2}.Release|x86.ActiveCfg = Release|Any CPU
+		{BF303B5E-3289-45FD-A285-5081B4CCBDB2}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/DEV_ENVIRONMENT.md
+++ b/docs/DEV_ENVIRONMENT.md
@@ -63,7 +63,7 @@ Now... if you run it, it should work. Visit `http://localhost:5000/app/api/admin
 
 ### Set up the backend on Visual Studio 2017
 
-Open the folder Traducir. Once there, double click Traducir.sln. This will open the backend solution. Before we can continue, we have to configure the enviroment variables. This variables are stored on traducir.api property pages. There are two ways to configure this variables.
+Open the folder Traducir. Once there, double click Traducir.sln. This will open the solution. Before we can continue, we have to configure the enviroment variables for the backend project. This variables are stored on the property pages for `Traducir.Api`. There are two ways to configure this variables.
 
 The hard way, is setting them up manually one by one on the property page of the project. Rigth Click on the project name (Traducir.Api) and click on properties. Go to debug tab, and select the profile IIS Express (should be selected by default). Once there, you can set up this variables on the grid that said environment variables
 


### PR DESCRIPTION
_Traducir.Web_ is now part of the Visual Studio solution as a Node.js project, so the full source code of the site can now be seen in the IDE.

Also the solution file has been updated to Visual Studio 2019 (but still can be used in Visual Studio 2017).