### PR TITLE
Add a read-only Transifex service for development

### DIFF
--- a/Traducir.Api/ReadonlyTransifexService.cs
+++ b/Traducir.Api/ReadonlyTransifexService.cs
@@ -1,0 +1,33 @@
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Traducir.Core.Models;
+using Traducir.Core.Models.Services;
+using Traducir.Core.Services;
+
+namespace Traducir.Api
+{
+    // To be used in development environment only
+    public class ReadonlyTransifexService : ITransifexService
+    {
+        private readonly TransifexService realService;
+        private readonly ILogger logger;
+
+        public ReadonlyTransifexService(TransifexService realService, ILoggerFactory loggerFactory)
+        {
+            this.realService = realService;
+            this.logger = loggerFactory.CreateLogger("TRANSIFEX SERVICE");
+        }
+
+        public Task<ImmutableArray<TransifexString>> GetStringsFromTransifexAsync()
+        {
+            return realService.GetStringsFromTransifexAsync();
+        }
+
+        public Task<bool> PushStringsToTransifexAsync(ImmutableArray<SOString> strings)
+        {
+            logger.LogInformation($"{strings.Length} strings were requested to be pushed to Transifex (they weren't)");
+            return Task.FromResult<bool>(true);
+        }
+    }
+}

--- a/docs/DEV_ENVIRONMENT.md
+++ b/docs/DEV_ENVIRONMENT.md
@@ -39,10 +39,10 @@ Open the project and go to Debug => Start Debugging. The first time it should as
 
 Stop it now... we need to configure the environment variables. Everything is set up using environment variables so that it's easy to keep track of them and to make it easy to set up when running the project inside a docker container (that's exactly how I'm running it on prod... and how I'll run it when we have tests. Yes, we will have tests some day).
 
-Open the `.vscode/launch.json` and replace the existing `env` key with the following (changing whatever is between `<>` with the appropriate values for you):
+Open the `.vscode/launch.json` and replace the existing `environmentVariables` key with the following (changing whatever is between `<>` with the appropriate values for you):
 
 ```
-"env": {
+"environmentVariables": {
     "ASPNETCORE_ENVIRONMENT": "Development",
     "FRIENDLY_NAME": "SOes",
     "CONNECTION_STRING": "Server=<SQL SERVER ADDRESS>;Database=Traducir;User Id=<SQL SERVER USER>;Password=<SQL SERVER PASSWORD>;Min Pool Size=5;",
@@ -55,7 +55,8 @@ Open the `.vscode/launch.json` and replace the existing `env` key with the follo
 
     "TRANSIFEX_APIKEY": "<YOUR TRANSIFEX API KEY>",
     "TRANSIFEX_RESOURCE_PATH": "api/2/project/stack-overflow-es/resource/english/translation/es/strings/",
-    "TRANSIFEX_LINK_PATH": "stack-exchange/stack-overflow-es/translate/#es/english"
+    "TRANSIFEX_LINK_PATH": "stack-exchange/stack-overflow-es/translate/#es/english",
+    "PUSH_TO_TRANSIFEX_ON_DEV": "False"
 },
 ```
 


### PR DESCRIPTION
Now by default the Transifex service used in development is read-only: trying to invoke the `/push` entry point will do nothing but write an entry in the log. This provides a "safe" development environment.

This can be disabled (so that strings are actually pushed) by setting the `PUSH_TO_TRANSIFEX_ON_DEV` configuration key to "True".