### PR TITLE
Fix profile link in history

### DIFF
--- a/Traducir.Web/Views/Users/SuggestionsByUser.cshtml
+++ b/Traducir.Web/Views/Users/SuggestionsByUser.cshtml
@@ -49,7 +49,7 @@
                                     @history.HistoryType.DisplayName()
                                 </td>
                                 <td>
-                                    <a href="https://@Model.SiteDomain/users/@Model.UserId"
+                                    <a href="https://@Model.SiteDomain/users/@history.UserId"
                                        target="_blank"
                                        title="at @suggestion.CreationDate.ToIsoFormat() UTC">
                                         @history.UserName


### PR DESCRIPTION
Currently the link is always to the profile of current logged user, it should be to the profile of user who made the action