### PR TITLE
Add translation history

### DIFF
--- a/Traducir.Web/Controllers/HomeController.cs
+++ b/Traducir.Web/Controllers/HomeController.cs
@@ -253,6 +253,18 @@ namespace Traducir.Web.Controllers
             return PartialView("EditString", viewModel);
         }
 
+        [Authorize]
+        [Route("strings/{stringId}/history")]
+        public async Task<IActionResult> SuggestionsByString(int stringId)
+        {
+            var suggestions = await _soStringsService.GetSuggestionsByString(stringId);
+            var siteDomain = _configuration.GetValue<string>("STACKAPP_SITEDOMAIN");
+            var str = await _soStringsService.GetStringByIdAsync(stringId);
+            var model = new SuggestionsByStringViewModel { SiteDomain = siteDomain, StringId = stringId, Suggestions = suggestions, String = str };
+
+            return View(model);
+        }
+
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
         public IActionResult Error()
         {

--- a/Traducir.Web/ViewModels/Home/SuggestionsByStringViewModel.cs
+++ b/Traducir.Web/ViewModels/Home/SuggestionsByStringViewModel.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Traducir.Core.Models;
+using Traducir.Core.Models.Enums;
+
+namespace Traducir.Web.ViewModels.Home
+{
+    public class SuggestionsByStringViewModel
+    {
+        public IEnumerable<SOStringSuggestion> Suggestions { get; set; }
+
+        public int StringId { get; set; }
+
+        public SOString String { get; set; }
+
+        public string SiteDomain { get; set; }
+
+        public static string BadgeClassForState(StringSuggestionState state)
+        {
+            switch (state)
+            {
+                case StringSuggestionState.Created:
+                    return "badge-secondary";
+                case StringSuggestionState.ApprovedByReviewer:
+                case StringSuggestionState.ApprovedByTrustedUser:
+                    return "badge-success";
+                case StringSuggestionState.Rejected:
+                    return "badge-danger";
+                case StringSuggestionState.DeletedByOwner:
+                    return "badge-dark";
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/Traducir.Web/Views/Home/EditString.cshtml
+++ b/Traducir.Web/Views/Home/EditString.cshtml
@@ -138,6 +138,13 @@
             </tbody>
         </table>
     }
+    
+    @if (Model.UserIsLoggedIn)
+    {
+        <div class="mt-2">
+            <a href="/strings/@(Model.String.Id)/history">Translation history</a>
+        </div>
+    }
 
     @if (Model.UserCanSuggest)
     {

--- a/Traducir.Web/Views/Home/SuggestionsByString.cshtml
+++ b/Traducir.Web/Views/Home/SuggestionsByString.cshtml
@@ -1,0 +1,75 @@
+@using System.Linq
+@using Traducir.Core.Helpers
+@using Traducir.Core.Models.Enums
+@using Traducir.Web.ViewModels.Home
+
+@model SuggestionsByStringViewModel
+
+<div class="container">
+    <div class="m-2 text-center">
+        <h2>Translation history</h2>
+    </div>
+    <div><span class="font-weight-bold">Original string:</span> <pre class="d-inline">@Model.String.OriginalString</pre></div>
+
+    @if (Model.Suggestions.Any())
+    {
+        foreach (var suggestion in Model.Suggestions)
+        {
+            <div class="mt-5">
+                <div>
+                    <span class="font-weight-bold">Suggestion:</span> <pre class="d-inline">@suggestion.Suggestion</pre>
+                </div>
+                <div>
+                    <span class="font-weight-bold">Author:</span> 
+                    <a href="https://@Model.SiteDomain/users/@suggestion.CreatedById" target="_blank">@suggestion.CreatedByName</a>
+                </div>
+                <div>
+                    <span class="font-weight-bold">State:</span> <span class="badge @SuggestionsByStringViewModel.BadgeClassForState(suggestion.State)">@suggestion.State.DisplayName()</span>
+                </div>
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Event</th>
+                            <th>User</th>
+                            <th>Comment</th>
+                            <th>Date</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var history in suggestion.Histories)
+                        {
+                            <tr>
+                                <td>
+                                    @history.HistoryType.DisplayName()
+                                </td>
+                                <td>
+                                    <a href="https://@Model.SiteDomain/users/@history.UserId"
+                                       target="_blank"
+                                       title="at @suggestion.CreationDate.ToIsoFormat() UTC">
+                                        @history.UserName
+                                    </a>
+                                </td>
+                                <td>
+                                    @history.Comment
+                                </td>
+                                <td>
+                                    @history.CreationDate.ToIsoFormat()
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+    }
+    else
+    {
+        <div class="row">
+            <div class="col">
+                <div class="mx-auto mt-5 w-50 p-3 text-center">
+                    <span>No results (sad trombone)</span>
+                </div>
+            </div>
+        </div>
+    }
+</div>


### PR DESCRIPTION
Add translation history page `strings/{stringId}/history` that displays all suggestions for a given string. The page is exposed to any logged user via hyperlink in string edit UI.

Fixes https://github.com/g3rv4/Traducir/issues/113
Fixes https://github.com/g3rv4/Traducir/issues/134