### PR TITLE
Upgraded to .NET 6 and minor tweaks before Transifex API upgrade

### DIFF
--- a/Traducir.Core/Services/ITransifexService.cs
+++ b/Traducir.Core/Services/ITransifexService.cs
@@ -1,0 +1,14 @@
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Traducir.Core.Models;
+using Traducir.Core.Models.Services;
+
+namespace Traducir.Core.Services
+{
+    public interface ITransifexService
+    {
+        Task<ImmutableArray<TransifexString>> GetStringsFromTransifexAsync();
+
+        Task<bool> PushStringsToTransifexAsync(ImmutableArray<SOString> strings);
+    }
+}

--- a/Traducir.Core/Services/ReadonlyTransifexService.cs
+++ b/Traducir.Core/Services/ReadonlyTransifexService.cs
@@ -9,10 +9,10 @@ namespace Traducir.Core.Services
     // To be used in development environment only
     public class ReadonlyTransifexService : ITransifexService
     {
-        private readonly TransifexService realService;
+        private readonly ITransifexService realService;
         private readonly ILogger logger;
 
-        public ReadonlyTransifexService(TransifexService realService, ILoggerFactory loggerFactory)
+        public ReadonlyTransifexService(ITransifexService realService, ILoggerFactory loggerFactory)
         {
             this.realService = realService;
             this.logger = loggerFactory.CreateLogger("TRANSIFEX SERVICE");

--- a/Traducir.Core/Services/TransifexService.cs
+++ b/Traducir.Core/Services/TransifexService.cs
@@ -13,13 +13,6 @@ using Traducir.Core.Models.Services;
 
 namespace Traducir.Core.Services
 {
-    public interface ITransifexService
-    {
-        Task<ImmutableArray<TransifexString>> GetStringsFromTransifexAsync();
-
-        Task<bool> PushStringsToTransifexAsync(ImmutableArray<SOString> strings);
-    }
-
     public class TransifexService : ITransifexService
     {
         private readonly string _apikey;

--- a/Traducir.Core/Services/TransifexService.cs
+++ b/Traducir.Core/Services/TransifexService.cs
@@ -48,6 +48,7 @@ namespace Traducir.Core.Services
         public Task<bool> PushStringsToTransifexAsync(ImmutableArray<SOString> strings)
         {
             throw new NotImplementedException("Method not available on a RISKY build");
+        }
 #else
         public async Task<bool> PushStringsToTransifexAsync(ImmutableArray<SOString> strings)
         {
@@ -83,8 +84,8 @@ namespace Traducir.Core.Services
 
                 return success;
             }
-#endif
         }
+#endif
 
         private HttpClient GetHttpClient()
         {

--- a/Traducir.Core/Traducir.Core.csproj
+++ b/Traducir.Core/Traducir.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>../ca.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/Traducir.Migrations/Traducir.Migrations.csproj
+++ b/Traducir.Migrations/Traducir.Migrations.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Traducir.Migrations/Traducir.Migrations.csproj
+++ b/Traducir.Migrations/Traducir.Migrations.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/Traducir.Web/Startup.cs
+++ b/Traducir.Web/Startup.cs
@@ -74,9 +74,11 @@ namespace Traducir.Web
                 {
                     loggingBuilder.AddConsole();
                 });
-                services.AddSingleton(typeof(ILoggerFactory), LoggerFactory);
-                services.AddSingleton(typeof(TransifexService), typeof(TransifexService));
-                services.AddSingleton(typeof(ITransifexService), typeof(ReadonlyTransifexService));
+
+                services.AddSingleton<ITransifexService>(serviceProvider =>
+                    new ReadonlyTransifexService(
+                        new TransifexService(Configuration, serviceProvider.GetService<ISOStringService>()),
+                        LoggerFactory));
             }
             else
             {

--- a/Traducir.Web/Traducir.Web.csproj
+++ b/Traducir.Web/Traducir.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <TypeScriptToolsVersion>3.7</TypeScriptToolsVersion>
     <CodeAnalysisRuleSet>../ca.ruleset</CodeAnalysisRuleSet>

--- a/ca.ruleset
+++ b/ca.ruleset
@@ -12,6 +12,7 @@
         <Rule Id="SA1116" Action="None" />
         <Rule Id="CA1034" Action="None" />
         <Rule Id="CA1720" Action="None" />
+        <Rule Id="CA2234" Action="None" />
 
         <Rule Id="CA1001" Action="Error" />
         <Rule Id="CA1009" Action="Error" />


### PR DESCRIPTION
I thought that it might be a good idea for us to ensure that the .NET 6 update doesn't cause any problems with the deployment / hosting process before we started pushing larger changes relating to updating the Transifex integration!

Note that I've suppressed the rule CA2234 ("[Pass System.Uri objects instead of strings](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2234)") because it didn't seem worth meddling with the existing code and this rule only started being applied after updating the target framework.